### PR TITLE
Feature cloud config file

### DIFF
--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -47,6 +47,15 @@ EOF
 
 coreos:
     etcd:
+EOF
+
+        if [[ -n "$HOSTNAME" ]]; then
+        cat >> cloud-config.yaml << EOF
+        name: ${HOSTNAME}
+EOF
+        fi
+
+        cat >> cloud-config.yaml << EOF
         # generate a new token for each unique cluster from https://discovery.etcd.io/new
         discovery: ${DISCOVERY_TOKEN}
         addr: $public_ipv4:4001

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -44,7 +44,7 @@ EOF
 EOF
     fi
 
-    if [[ -n "$DISCOVERY" ]]; then
+    if [[ -z "$PRIVATE" -o -n "$DISCOVERY" ]]; then
         cat >> cloud-config.yaml << EOF
 
 coreos:

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -69,6 +69,16 @@ EOF
 
     fleet:
         public-ip: $public_ipv4
+EOF
+
+        if [[ -n "$METADATA" ]]; then
+
+            cat >> cloud-config.yaml << EOF
+        metadata: ${METADATA}
+EOF
+        fi
+
+        cat >> cloud-config.yaml << EOF
 
     units:
         - name: etcd.service

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -55,11 +55,17 @@ EOF
 EOF
         fi
 
+        if [[ -n "$CROSS_CLOUD" ]]; then
+            PEER_ADDR="\$public_ipv4"
+        else
+            PEER_ADDR="\$private_ipv4"
+        fi
+
         cat >> cloud-config.yaml << EOF
         # generate a new token for each unique cluster from https://discovery.etcd.io/new
         discovery: ${DISCOVERY_TOKEN}
         addr: $public_ipv4:4001
-        peer-addr: $private_ipv4:7001
+        peer-addr: ${PEER_ADDR}:7001
 
     fleet:
         public-ip: $public_ipv4

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -7,6 +7,8 @@ cd $(dirname $0)
 stage1()
 {
     cd /root
+
+    PUBLIC=$(ip addr show dev eth0 | grep 'inet.*eth0' | awk '{print $2}')
     cat > cloud-config.yaml << EOF
 #cloud-config
 
@@ -21,7 +23,7 @@ write_files:
       Name=ens3
       
       [Network]
-      Address=$(ip addr show dev eth0 | grep 'inet.*eth0' | awk '{print $2}')
+      Address=$PUBLIC
       Gateway=$(route | grep default | awk '{print $2}')
       DNS=8.8.4.4
       DNS=8.8.8.8
@@ -56,9 +58,9 @@ EOF
         fi
 
         if [[ -n "$CROSS_CLOUD" ]]; then
-            PEER_ADDR="\$public_ipv4"
+            PEER_ADDR=$(echo $PUBLIC | sed 's/\/[0-9]\+$//')
         else
-            PEER_ADDR="\$private_ipv4"
+            PEER_ADDR=$(echo $PRIVATE | sed 's/\/[0-9]\+$//')
         fi
 
         cat >> cloud-config.yaml << EOF

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -42,6 +42,26 @@ EOF
 EOF
     fi
 
+    if [[ -n "$DISCOVERY" ]]; then
+        cat >> cloud-config.yaml << EOF
+
+coreos:
+    etcd:
+        # generate a new token for each unique cluster from https://discovery.etcd.io/new
+        discovery: ${DISCOVERY_TOKEN}
+        addr: $public_ipv4:4001
+        peer-addr: $private_ipv4:7001
+
+    fleet:
+        public-ip: $public_ipv4
+
+    units:
+        - name: etcd.service
+          command: start
+        - name: fleet.service
+          command: start
+EOF
+
     wget http://alpha.release.core-os.net/amd64-usr/current/coreos_production_pxe.vmlinuz
     wget http://alpha.release.core-os.net/amd64-usr/current/coreos_production_pxe_image.cpio.gz
 

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -63,7 +63,7 @@ EOF
 
         cat >> cloud-config.yaml << EOF
         # generate a new token for each unique cluster from https://discovery.etcd.io/new
-        discovery: ${DISCOVERY_TOKEN}
+        discovery: ${DISCOVERY}
         addr: \$public_ipv4:4001
         peer-addr: ${PEER_ADDR}:7001
 

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -72,7 +72,6 @@ EOF
 EOF
 
         if [[ -n "$METADATA" ]]; then
-
             cat >> cloud-config.yaml << EOF
         metadata: ${METADATA}
 EOF

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -68,7 +68,7 @@ EOF
         peer-addr: ${PEER_ADDR}:7001
 
     fleet:
-        public-ip: $public_ipv4
+        public-ip: \$public_ipv4
 EOF
 
         if [[ -n "$METADATA" ]]; then

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -25,8 +25,22 @@ write_files:
       Gateway=$(route | grep default | awk '{print $2}')
       DNS=8.8.4.4
       DNS=8.8.8.8
-
 EOF
+
+    PRIVATE=$(ip addr show dev eth1 | grep 'inet.*eth1' | awk '{print $2}')
+    if [[ -n "$PRIVATE" ]]; then
+        cat >> cloud-config.yaml << EOF
+
+  - path: /etc/systemd/network/private.network
+    permissions: 0644
+    content: |
+      [Match]
+      Name=ens4v1
+      
+      [Network]
+      Address=${PRIVATE}
+EOF
+    fi
 
     wget http://alpha.release.core-os.net/amd64-usr/current/coreos_production_pxe.vmlinuz
     wget http://alpha.release.core-os.net/amd64-usr/current/coreos_production_pxe_image.cpio.gz

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -66,11 +66,11 @@ EOF
         cat >> cloud-config.yaml << EOF
         # generate a new token for each unique cluster from https://discovery.etcd.io/new
         discovery: ${DISCOVERY}
-        addr: \$public_ipv4:4001
+        addr: $(echo $PUBLIC | sed 's/\/[0-9]\+$//'):4001
         peer-addr: ${PEER_ADDR}:7001
 
     fleet:
-        public-ip: \$public_ipv4
+        public-ip: $(echo $PUBLIC | sed 's/\/[0-9]\+$//')
 EOF
 
         if [[ -n "$METADATA" ]]; then

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -44,7 +44,7 @@ EOF
 EOF
     fi
 
-    if [[ -z "$PRIVATE" -o -n "$DISCOVERY" ]]; then
+    if [[ -n "$DISCOVERY" ]]; then
         cat >> cloud-config.yaml << EOF
 
 coreos:
@@ -57,7 +57,7 @@ EOF
 EOF
         fi
 
-        if [[ -n "$CROSS_CLOUD" ]]; then
+        if [ -z "$PRIVATE" -o -n "$CROSS_CLOUD" ]; then
             PEER_ADDR=$(echo $PUBLIC | sed 's/\/[0-9]\+$//')
         else
             PEER_ADDR=$(echo $PRIVATE | sed 's/\/[0-9]\+$//')

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -10,6 +10,9 @@ stage1()
     cat > cloud-config.yaml << EOF
 #cloud-config
 
+ssh_authorized_keys:
+  - $(cat /root/.ssh/authorized_keys | head -1)
+
 write_files:
   - path: /etc/systemd/network/do.network
     permissions: 0644
@@ -23,8 +26,6 @@ write_files:
       DNS=8.8.4.4
       DNS=8.8.8.8
 
-ssh_authorized_keys:
-  - $(cat /root/.ssh/authorized_keys | head -1)
 EOF
 
     wget http://alpha.release.core-os.net/amd64-usr/current/coreos_production_pxe.vmlinuz

--- a/coreos-on-do.sh
+++ b/coreos-on-do.sh
@@ -64,7 +64,7 @@ EOF
         cat >> cloud-config.yaml << EOF
         # generate a new token for each unique cluster from https://discovery.etcd.io/new
         discovery: ${DISCOVERY_TOKEN}
-        addr: $public_ipv4:4001
+        addr: \$public_ipv4:4001
         peer-addr: ${PEER_ADDR}:7001
 
     fleet:


### PR DESCRIPTION
Extended cloud-config.yaml file with some common and sane settings.

Added support for private network.
If private network is available it is used for etcd peer address unless `CROSS_CLOUD=1` is set.

Basic settings for fleet:
`HOSTNAME=coreos01`
`METADATA="disk=ssd,provider=digital-ocean"`
and etcd:
`DISCOVERY=https://discovery.etcd.io/<token>`

EDIT: Replaced ip variables with actual values.
